### PR TITLE
update homebrew instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Independently of how you install **Brooklyn**, please **close your System Prefer
 ### Homebrew 🍺
 
 1. Open terminal
-2. Enter `brew cask install brooklyn`
+2. Enter `brew install --cask brooklyn`
 
 ## Uninstallation 🗑️
 
@@ -50,7 +50,7 @@ Independently of how you install **Brooklyn**, please **close your System Prefer
 ### Homebrew 🍺
 
 1. Open terminal
-2. Enter `brew cask uninstall brooklyn`
+2. Enter `brew uninstall --cask brooklyn`
 
 ## Compatibility 🔧
 


### PR DESCRIPTION
## What was done?
* Updated Homebrew instructions in the README

## Why?
This was mainly done because `brew cask install` was deprecated in Homebrew 2.6.0 and was disabled in Homebrew 2.7.0 in favor of `brew install --cask`