### PR TITLE
Troubleshooting for BigSur security quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Independently of how you install **Brooklyn**, please **close your System Prefer
 
 Requires OS X El Capitan (10.11) or above.
 
+## Troubleshooting 🤕
+
+The Brooklyn screen saver can be blocked by the system as a malicious software. Sometimes on macOS Big Sur clicking `Open Anyway` in `Security & Privacy` is not fixing the issue.  
+
+To bypass this quarantine made by apple, you can use this command in your terminal :
+
+```shell
+sudo xattr -d com.apple.quarantine ~/"Library/Screen Savers/Brooklyn.saver"
+```
+
 ## Support Brooklyn ❤️
 
 Hello there 👋


### PR DESCRIPTION
## What was done?
This PR aim at adding a troubleshooting section in the readme.

Moreover it adds an helper to unlock people with macOS Big Sur blocked by the apple quarantine saying the screen saver is not safe. 

Thus this helper contains a command line to bypass the quarantine.

## Why?
This was mainly done because ...

[CF this issue](https://github.com/pedrommcarrasco/Brooklyn/issues/95)

## Screenshots
![image](https://user-images.githubusercontent.com/32762860/135591617-bab86a60-07cb-4e83-9fb7-4d31cfc909b6.png)
