### PR TITLE
Modify the background color for wide monitors

### DIFF
--- a/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
+++ b/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
@@ -19,7 +19,7 @@ final class BrooklynView: ScreenSaverView {
     // MARK: Constant
     private enum Constant {
         static let secondPerFrame = 1.0 / 30.0
-        static let backgroundColor = NSColor(red: 0.00, green: 0.01, blue: 0.00, alpha:1.0)
+        static let backgroundColor = NSColor(red: 0.00, green: 0.00, blue: 0.00, alpha:1.0)
     }
     
     // MARK: Outlets


### PR DESCRIPTION
## What was done?
In this PR, I modify the background color to make it black.

## Why?
I've upgraded my monitor to 32:9 and occurring an issue that has a little bit of green on each side when running the screen saver. And I think it is the same issue as #50 

<img src="https://user-images.githubusercontent.com/52045032/197249178-d49270b8-686e-41b9-bb8a-f19c454e3780.png" width="640" height="180" />

<img src="https://user-images.githubusercontent.com/52045032/197249903-d94e1678-0344-4a2b-aca1-ff60a32ca2cd.jpg" width="300" height="200" />

## Screenshots
<img src="https://user-images.githubusercontent.com/52045032/197251383-26a6ff36-603f-43f8-808e-d63147be762e.jpg" width="640" height="180" />

<img src="https://user-images.githubusercontent.com/52045032/197251467-1cb04baf-2b09-4a40-8116-64d08d27fa19.jpg" width="300" height="200" />
