### PR TITLE
Improve `install` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@
 
 ## Installation 📦
 
-Independently of how you install **Brooklyn**, please **close your System Preferences**
+Independently of how you install **Brooklyn**, please **close your System Preferences**.
+
+Screen savers can be set programmatically with this Terminal command :
+
+```shell
+defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName Brooklyn path "$HOME/Library/Screen Savers/Brooklyn.saver"
+```
 
 ### Manual :hand:
 
@@ -38,7 +44,7 @@ Independently of how you install **Brooklyn**, please **close your System Prefer
 ### Homebrew 🍺
 
 1. Open terminal
-2. Enter `brew install --cask brooklyn`
+2. Enter `brew install --cask brooklyn --no-quarantine`
 
 ## Uninstallation 🗑️
 


### PR DESCRIPTION
## What was done?
* Added the `--no-quarantine` flag to Home`brew` `install` instructions. This alleviates the potential problem described in [Troubleshooting](https://github.com/pedrommcarrasco/Brooklyn#troubleshooting-).
* Added shell command to easily set the screen saver from Terminal or a script.

## Why?
This was mainly done for ease of use and for reference.