### PR TITLE
Fix unbounded queue growth causing high CPU/memory after extended use

### DIFF
--- a/Brooklyn/Contexts/LoopPlayer.swift
+++ b/Brooklyn/Contexts/LoopPlayer.swift
@@ -10,7 +10,12 @@ import AVFoundation
 
 // MARK: - LoopPlayer
 final class LoopPlayer: AVQueuePlayer {
-    
+
+    // Tracks ObjectIdentifiers of items that belong to this player instance,
+    // so we can filter out AVPlayerItemDidPlayToEndTime notifications from other
+    // LoopPlayer instances (e.g. screensaver preview + main display, multi-monitor).
+    private var managedItemIDs: Set<ObjectIdentifier> = []
+
     // MARK: Lifecycle
     init(items: [Animation], numberOfLoops: Int, shouldRandomize: Bool) {
         let items = (shouldRandomize ? items.shuffled() : items)
@@ -19,16 +24,17 @@ final class LoopPlayer: AVQueuePlayer {
                 $0.append(contentsOf: Array(copy: item, count: numberOfLoops))
             }
             .prepareForQueue()
-        
+
         super.init(items: items)
+        items.forEach { managedItemIDs.insert(ObjectIdentifier($0)) }
         observe()
     }
-    
+
     override init() {
         super.init()
     }
-    
-    
+
+
     deinit {
         unobserve()
     }
@@ -40,8 +46,11 @@ extension LoopPlayer {
     func play(_ animation: Animation) {
         guard let item = AVPlayerItem(video: animation, extension: .mp4, for: LoopPlayer.self) else { return }
         actionAtItemEnd = .none
+        managedItemIDs.removeAll()
         removeAllItems()
-        [item].prepareForQueue().forEach {
+        let prepared = [item].prepareForQueue()
+        prepared.forEach {
+            managedItemIDs.insert(ObjectIdentifier($0))
             insert($0, after: items().last)
         }
         actionAtItemEnd = .advance
@@ -65,9 +74,13 @@ private extension LoopPlayer {
     }
     
     @objc
-    func playerItemDidFinish() {
-        guard let currentItemCopy = currentItem?.copy() as? AVPlayerItem else { return }
-        insert(currentItemCopy, after: items().last)
+    func playerItemDidFinish(_ notification: Notification) {
+        guard let finishedItem = notification.object as? AVPlayerItem,
+              managedItemIDs.contains(ObjectIdentifier(finishedItem)) else { return }
+        managedItemIDs.remove(ObjectIdentifier(finishedItem))
+        guard let itemCopy = currentItem?.copy() as? AVPlayerItem else { return }
+        managedItemIDs.insert(ObjectIdentifier(itemCopy))
+        insert(itemCopy, after: items().last)
     }
 }
 

--- a/Brooklyn/Contexts/LoopPlayer.swift
+++ b/Brooklyn/Contexts/LoopPlayer.swift
@@ -42,7 +42,12 @@ final class LoopPlayer: AVQueuePlayer {
 
 // MARK: - Actions
 extension LoopPlayer {
-    
+
+    func stop() {
+        managedItemIDs.removeAll()
+        removeAllItems()
+    }
+
     func play(_ animation: Animation) {
         guard let item = AVPlayerItem(video: animation, extension: .mp4, for: LoopPlayer.self) else { return }
         actionAtItemEnd = .none

--- a/Brooklyn/Contexts/Preferences/PreferencesWindowController.swift
+++ b/Brooklyn/Contexts/Preferences/PreferencesWindowController.swift
@@ -95,7 +95,6 @@ extension PreferencesWindowController: NSTableViewDataSource {
         guard let item = manager.availableAnimations[safe: row] else { return nil }
         let cell = tableView.dequeueCell(for: self, as: AnimationCellView.self)
         cell.configure(with: item.name, state: manager.selectedAnimations.contains(item) ? .on : .off)
-        debugPrint("Brooklyn | \(item.name)")
         cell.onToogle = { [weak manager] in manager?.toogle(item) }
         return cell
     }

--- a/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
+++ b/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
@@ -18,7 +18,6 @@ final class BrooklynView: ScreenSaverView {
     
     // MARK: Constant
     private enum Constant {
-        static let secondPerFrame = 1.0 / 30.0
         static let backgroundColor = NSColor(red: 0.00, green: 0.01, blue: 0.00, alpha:1.0)
     }
     
@@ -32,13 +31,11 @@ final class BrooklynView: ScreenSaverView {
     // MARK: Initialization
     required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
-        animationTimeInterval = Constant.secondPerFrame
         configure()
     }
-    
+
     override init?(frame: NSRect, isPreview: Bool) {
         super.init(frame: frame, isPreview: isPreview)
-        animationTimeInterval = Constant.secondPerFrame
         configure()
     }
 }

--- a/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
+++ b/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
@@ -51,6 +51,8 @@ extension BrooklynView {
     override func stopAnimation() {
         super.stopAnimation()
         manager.player.pause()
+        manager.player.removeAllItems()
+        videoLayer.player = nil
     }
 }
 

--- a/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
+++ b/Brooklyn/Contexts/Screen Saver/BrooklynView.swift
@@ -45,13 +45,14 @@ extension BrooklynView {
     
     override func startAnimation() {
         super.startAnimation()
+        videoLayer.player = manager.player
         manager.player.play()
     }
     
     override func stopAnimation() {
         super.stopAnimation()
         manager.player.pause()
-        manager.player.removeAllItems()
+        manager.player.stop()
         videoLayer.player = nil
     }
 }


### PR DESCRIPTION
## Problems

### 1. Unbounded queue growth (memory/CPU leak during extended use)

\`LoopPlayer\` observed \`AVPlayerItemDidPlayToEndTime\` with \`object: nil\`, which means **every instance receives notifications from all other instances** — including the System Preferences preview player, the full-screen screensaver player, and additional players on secondary displays.

Each instance responds by inserting an extra \`AVPlayerItem\` into its own queue. Items are only removed from the front (by \`AVQueuePlayer\` advancement), but foreign notifications add items to the back without any corresponding removal. The queue grows without bound the longer the screensaver runs, causing CPU and memory usage to climb over time. The bug is harder to reproduce because it requires extended runtime and is more pronounced in multi-monitor setups.

### 2. AVPlayer resources not released on exit (memory leak after screensaver exits)

\`stopAnimation()\` only called \`pause()\`. This left all \`AVPlayerItem\`s loaded in the queue and kept \`videoLayer\` holding a strong reference to the player, preventing deallocation. \`VTDecoderXPCService\` (the system video decoder XPC service) stayed alive and retained its memory after the screensaver exited — confirmed via Activity Monitor.

### 3. Broken start/stop symmetry

\`stopAnimation()\` set \`videoLayer.player = nil\` and drained the queue, but \`startAnimation()\` never restored the player reference. Apple's docs state that \`startAnimation\`/\`stopAnimation\` may be called multiple times on the same instance. Without restoration, subsequent activations render a black screen.

Additionally, calling the inherited \`AVQueuePlayer.removeAllItems()\` directly bypassed \`LoopPlayer\`'s internal \`managedItemIDs\` bookkeeping, leaving stale \`ObjectIdentifier\`s that would cause \`playerItemDidFinish\` to silently drop all loop-continuation events.

## Fixes

**Queue growth:** Track each \`LoopPlayer\` instance's own items using a \`Set<ObjectIdentifier>\`. In \`playerItemDidFinish(_:)\`, verify the finished item belongs to this player before acting. Items are registered on insertion and removed on consumption; the set is also cleared in \`play(_:)\` before \`removeAllItems()\` to prevent stale \`ObjectIdentifier\` values from aliasing newly allocated items.

**Exit cleanup:** In \`stopAnimation()\`, call \`removeAllItems()\` to release all queued \`AVPlayerItem\`s, then set \`videoLayer.player = nil\` to drop the layer's retain on the player. This allows \`VTDecoderXPCService\` to terminate cleanly when the screensaver exits.

**Start/stop symmetry:** Added \`LoopPlayer.stop()\` which clears \`managedItemIDs\` before calling \`removeAllItems()\`, keeping internal state consistent. \`stopAnimation()\` now calls \`player.stop()\` instead of the inherited method directly. \`startAnimation()\` restores \`videoLayer.player = manager.player\` so the layer-player connection is valid on every activation.

## Additional cleanup

Remove the unused \`animationTimeInterval = 1/30\` timer in \`BrooklynView\`. \`animateOneFrame()\` is never overridden, so the \`ScreenSaverView\` framework was firing an empty 30 fps callback while AVFoundation handled all rendering — wasted CPU with no effect.

Remove leftover \`debugPrint\` from the preferences table datasource.

## Files changed

- \`Brooklyn/Contexts/LoopPlayer.swift\`
- \`Brooklyn/Contexts/Screen Saver/BrooklynView.swift\`
- \`Brooklyn/Contexts/Preferences/PreferencesWindowController.swift\`